### PR TITLE
Add PROJECT variable for custom project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # docker-enviroment
-Docker enviroment with Apache, MariaDB and PHP
+
+Entorno de contenedores Docker que incluye:
+
+- Apache con PHP en su versión más reciente.
+- MariaDB como base de datos.
+- Instalación automática de Symfony. Puede indicarse la versión mediante la variable `SYMFONY_VERSION`; si no se especifica se usa la 6.4.
+- El nombre del proyecto Symfony puede definirse con la variable `PROJECT`; por defecto es `my_project`. La base de datos se llamará `${PROJECT}_db`.
+
+## Uso
+
+1. Construye las imágenes y levanta los contenedores:
+
+```bash
+docker compose up -d --build
+```
+
+Puedes definir la versión de Symfony y el nombre del proyecto al construir con las variables de entorno `SYMFONY_VERSION` y `PROJECT`:
+
+```bash
+SYMFONY_VERSION=5.4 PROJECT=blog docker compose up -d --build
+```
+
+2. Accede a la aplicación en [http://localhost](http://localhost).
+
+Los datos de MariaDB se almacenan en el volumen `db-data`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+
+services:
+  web:
+    build:
+      context: ./web
+      args:
+        SYMFONY_VERSION: ${SYMFONY_VERSION-6.4}
+        PROJECT: ${PROJECT-my_project}
+    ports:
+      - "80:80"
+    volumes:
+      - ./web:/var/www/html/${PROJECT:-my_project}
+    depends_on:
+      - db
+  db:
+    image: mariadb:latest
+    environment:
+      MARIADB_ROOT_PASSWORD: example
+      MARIADB_DATABASE: "${PROJECT:-my_project}_db"
+      MARIADB_USER: symfony
+      MARIADB_PASSWORD: symfony
+    volumes:
+      - db-data:/var/lib/mysql
+
+volumes:
+  db-data:

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,20 @@
+FROM php:8.3-apache
+
+# Arguments to specify Symfony version and project name
+ARG SYMFONY_VERSION=6.4
+ARG PROJECT=my_project
+ENV SYMFONY_VERSION=${SYMFONY_VERSION}
+ENV PROJECT=${PROJECT}
+
+# Install dependencies and Composer
+RUN apt-get update \
+    && apt-get install -y git unzip zip \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Symfony skeleton in the Apache document root using PROJECT name
+RUN composer create-project symfony/skeleton:"${SYMFONY_VERSION}" /var/www/html/${PROJECT}
+
+RUN a2enmod rewrite
+
+WORKDIR /var/www/html/${PROJECT}


### PR DESCRIPTION
## Summary
- support PROJECT variable in Dockerfile and docker-compose
- create Symfony project using PROJECT name
- database name now `${PROJECT}_db`
- update README instructions

## Testing
- `docker compose version` *(fails: command not found)*