### PR TITLE
Add PROJECT variable and runtime installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # docker-enviroment
-Docker enviroment with Apache, MariaDB and PHP
+
+Entorno de contenedores Docker que incluye:
+
+- Apache con PHP en su versión más reciente.
+- MariaDB como base de datos.
+- Instalación automática de Symfony. Puede indicarse la versión mediante la variable `SYMFONY_VERSION`; si no se especifica se usa la `6.4`.
+
+## Variables disponibles
+
+- `SYMFONY_VERSION`: Versión de Symfony a instalar. Por defecto `6.4`.
+- `PROJECT`: Nombre del proyecto Symfony y de la base de datos (`${PROJECT}_db`). Por defecto `my_project`.
+
+## Uso
+
+1. Construye las imágenes y levanta los contenedores:
+
+```bash
+docker compose up -d --build
+```
+
+Puedes definir la versión de Symfony al construir con la variable de entorno `SYMFONY_VERSION`:
+
+```bash
+PROJECT=blog SYMFONY_VERSION=5.4 docker compose up -d --build
+```
+
+2. Accede a la aplicación en [http://localhost](http://localhost).
+
+El código del proyecto se sincroniza con la carpeta `./${PROJECT}` de tu máquina, de modo que los cambios se aplican al instante.
+
+Los datos de MariaDB se almacenan en el volumen `db-data`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+
+services:
+  web:
+    build:
+      context: ./web
+      args:
+        SYMFONY_VERSION: ${SYMFONY_VERSION:-6.4}
+        PROJECT: ${PROJECT:-my_project}
+    environment:
+      SYMFONY_VERSION: ${SYMFONY_VERSION:-6.4}
+      PROJECT: ${PROJECT:-my_project}
+    ports:
+      - "80:80"
+    volumes:
+      - ./${PROJECT:-my_project}:/var/www/html/${PROJECT:-my_project}
+    depends_on:
+      - db
+  db:
+    image: mariadb:latest
+    environment:
+      MARIADB_ROOT_PASSWORD: example
+      MARIADB_DATABASE: "${PROJECT:-my_project}_db"
+      MARIADB_USER: symfony
+      MARIADB_PASSWORD: symfony
+    volumes:
+      - db-data:/var/lib/mysql
+
+volumes:
+  db-data:

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,23 @@
+FROM php:8.3-apache
+
+# Arguments to configure the Symfony project
+ARG SYMFONY_VERSION=6.4
+ARG PROJECT=my_project
+ENV SYMFONY_VERSION=${SYMFONY_VERSION}
+ENV PROJECT=${PROJECT}
+
+# Install dependencies and Composer
+RUN apt-get update \
+    && apt-get install -y git unzip zip \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy entrypoint script
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+RUN a2enmod rewrite
+
+WORKDIR /var/www/html/${PROJECT}
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+PROJECT_DIR=/var/www/html/${PROJECT}
+if [ ! -d "$PROJECT_DIR" ] || [ -z "$(ls -A "$PROJECT_DIR" 2>/dev/null)" ]; then
+  composer create-project symfony/skeleton:"${SYMFONY_VERSION}" "$PROJECT_DIR"
+fi
+exec apache2-foreground
+


### PR DESCRIPTION
## Summary
- add PROJECT build argument and environment variable
- create entrypoint script to generate Symfony project at runtime
- update compose file to mount project directory and set DB name
- document available variables and synced folder

## Testing
- `docker compose version` *(fails: command not found)*