### PR TITLE
Add gitignore for Symfony directory

### DIFF
--- a/symfony/.gitignore
+++ b/symfony/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything generated inside the Symfony project
+*
+!/.gitignore
+!/.gitkeep


### PR DESCRIPTION
## Summary
- ignore all generated files inside the `symfony` directory so the project files don't get committed

## Testing
- `docker compose config -q` *(fails: `docker: command not found`)*
- `bash -n web/entrypoint.sh`
