### PR TITLE
EEE-0001/Delete-variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ Entorno de contenedores Docker que incluye:
 
 - Apache con PHP en su versión más reciente.
 - MariaDB como base de datos.
-- Instalación automática de Symfony. Puede indicarse la versión mediante la variable `SYMFONY_VERSION`; si no se especifica se usa la 6.4.
-
-- El nombre del proyecto Symfony puede definirse con la variable `PROJECT`; por defecto es `my_project`. La base de datos se llamará `${PROJECT}_db`.
+- Instalación automática de Symfony 6.4 en el proyecto `demo`.
 
 
 ## Uso
@@ -17,18 +15,6 @@ Entorno de contenedores Docker que incluye:
 docker compose up -d --build
 ```
 
-Puedes definir la versión de Symfony al construir con la variable de entorno `SYMFONY_VERSION` y el nombre del proyecto con `PROJECT`:
-
-```bash
-SYMFONY_VERSION=5.4 PROJECT=demo docker compose up -d --build
-=======
-Puedes definir la versión de Symfony y el nombre del proyecto al construir con las variables de entorno `SYMFONY_VERSION` y `PROJECT`:
-
-```bash
-SYMFONY_VERSION=5.4 PROJECT=blog docker compose up -d --build
-
-```
-
 2. Accede a la aplicación en [http://localhost](http://localhost).
 
 Los datos de MariaDB se almacenan en el volumen `db-data`.
@@ -37,9 +23,5 @@ El código del proyecto Symfony se sincroniza con la carpeta `./symfony` del hos
 por lo que cualquier cambio en esa carpeta se refleja de inmediato en el conten
 edor.
 
-## Variables disponibles
 
-- `SYMFONY_VERSION`: versión de Symfony a instalar (por defecto `6.4`).
-- `PROJECT`: nombre del proyecto Symfony y de la base de datos (por defecto `my_project`).
-=======
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,20 +4,17 @@ services:
   web:
     build:
       context: ./web
-      args:
-        SYMFONY_VERSION: ${SYMFONY_VERSION-6.4}
-        PROJECT: ${PROJECT-my_project}
     ports:
       - "80:80"
     volumes:
-      - ./symfony:/var/www/html/${PROJECT-my_project}
+      - ./symfony:/var/www/html/demo
     depends_on:
       - db
   db:
     image: mariadb:latest
     environment:
       MARIADB_ROOT_PASSWORD: example
-      MARIADB_DATABASE: "${PROJECT-my_project}_db"
+      MARIADB_DATABASE: "demo_db"
       MARIADB_USER: symfony
       MARIADB_PASSWORD: symfony
     volumes:

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,13 +1,8 @@
 FROM php:8.3-apache
 
 
-# Configurable arguments
-
-ARG SYMFONY_VERSION=6.4
-ARG PROJECT=my_project
-ENV SYMFONY_VERSION=${SYMFONY_VERSION}
-ENV PROJECT=${PROJECT}
-ENV APACHE_DOCUMENT_ROOT=/var/www/html/${PROJECT}/public
+# Install Symfony 6.4 in project "demo"
+ENV APACHE_DOCUMENT_ROOT=/var/www/html/demo/public
 
 # Install dependencies and Composer
 RUN apt-get update \
@@ -28,9 +23,9 @@ RUN chmod +x /entrypoint.sh
 WORKDIR /var/www/html
 ENTRYPOINT ["/entrypoint.sh"]
 
-# Install Symfony skeleton in the Apache document root using PROJECT name
-RUN composer create-project symfony/skeleton:"${SYMFONY_VERSION}" /var/www/html/${PROJECT}
+# Install Symfony skeleton in the Apache document root
+RUN composer create-project symfony/skeleton:"6.4" /var/www/html/demo
 
 RUN a2enmod rewrite
 
-WORKDIR /var/www/html/${PROJECT}
+WORKDIR /var/www/html/demo

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e
 
-PROJECT_DIR="/var/www/html/${PROJECT}"
+PROJECT_DIR="/var/www/html/demo"
 
 if [ ! -d "$PROJECT_DIR" ] || [ -z "$(ls -A "$PROJECT_DIR" 2>/dev/null)" ]; then
-    composer create-project symfony/skeleton:"${SYMFONY_VERSION}" "$PROJECT_DIR"
+    composer create-project symfony/skeleton:"6.4" "$PROJECT_DIR"
     chown -R www-data:www-data "$PROJECT_DIR"
 fi
 


### PR DESCRIPTION
## Summary
- drop build args and project variables
- hardcode Symfony 6.4 demo project
- simplify README without environment variables

## Testing
- `bash -n web/entrypoint.sh`
- `docker compose config -q` *(fails: `docker` command not found)*