### PR TITLE
Fix create-project check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,5 @@
 - Update installation of Symfony skeleton to version `6.4.*`.
 - Mount host `symfony` folder to `/var/www/html` so the `demo` directory syncs automatically.
 - Create the project only when the `symfony` folder is empty.
+- Improve entrypoint to skip `composer create-project` when any subdirectory exists.
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,12 @@ docker compose up -d --build
 Los datos de MariaDB se almacenan en el volumen `db-data`.
 
 El código del proyecto Symfony se sincroniza con la carpeta `./symfony` del host.
-Al iniciar por primera vez se crea en ella el directorio `demo`, que contiene el proyecto Symfony;
-cualquier cambio dentro de esa carpeta se refleja de inmediato en el contenedor.
+Al iniciar por primera vez se crea en ella el directorio `demo`, que contiene el proyecto Symfony.
+En posteriores arranques, el script de entrada comprueba si dentro de `symfony` existe
+algún subdirectorio (por ejemplo `demo`, `blog`, `todo`). Si no encuentra ninguno,
+ejecuta `composer create-project` para generar un nuevo proyecto; de lo contrario,
+se reutilizan los archivos existentes. Cualquier cambio dentro de esa carpeta se
+refleja de inmediato en el contenedor.
 
 
 

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -4,8 +4,8 @@ set -e
 BASE_DIR="/var/www/html"
 PROJECT_DIR="$BASE_DIR/demo"
 
-# Create the Symfony skeleton only when the base directory has no subdirectories
-if [ -z "$(find "$BASE_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null)" ]; then
+# Create the Symfony skeleton only if no folders exist in "$BASE_DIR"
+if [ -z "$(find "$BASE_DIR" -mindepth 1 -maxdepth 1 -type d -print -quit)" ]; then
     composer create-project symfony/skeleton:"6.4.*" "$PROJECT_DIR"
     chown -R www-data:www-data "$PROJECT_DIR"
 fi


### PR DESCRIPTION
## Summary
- skip `composer create-project` unless no folder exists in `symfony`
- document the initialization logic
- note change in changelog

## Testing
- `bash -n web/entrypoint.sh`
- `docker compose config -q` *(fails: command not found)*