### PR TITLE
Fix composer execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,6 @@
 - Update installation of Symfony skeleton to version `6.4.*`.
 - Mount host `symfony` folder to `/var/www/html` so the `demo` directory syncs automatically.
 - Create the project only when the `symfony` folder is empty.
+- Improve entrypoint to skip `composer create-project` when any subdirectory exists.
+- Run `composer create-project` unconditionally at container build time.
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ docker compose up -d --build
 Los datos de MariaDB se almacenan en el volumen `db-data`.
 
 El código del proyecto Symfony se sincroniza con la carpeta `./symfony` del host.
-Al iniciar por primera vez se crea en ella el directorio `demo`, que contiene el proyecto Symfony;
-cualquier cambio dentro de esa carpeta se refleja de inmediato en el contenedor.
+Cada vez que se construye el contenedor se ejecuta `composer create-project` para 
+generar en dicha carpeta el directorio `demo`, sobrescribiendo cualquier contenido
+preexistente. Cualquier cambio dentro de `symfony` se refleja de inmediato en el
+contenedor.
 
 
 

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -4,10 +4,8 @@ set -e
 BASE_DIR="/var/www/html"
 PROJECT_DIR="$BASE_DIR/demo"
 
-# Create the Symfony skeleton only when the base directory has no subdirectories
-if [ -z "$(find "$BASE_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null)" ]; then
-    composer create-project symfony/skeleton:"6.4.*" "$PROJECT_DIR"
-    chown -R www-data:www-data "$PROJECT_DIR"
-fi
+# Always (re)create the Symfony skeleton in the mounted directory
+composer create-project symfony/skeleton:"6.4.*" "$PROJECT_DIR"
+chown -R www-data:www-data "$PROJECT_DIR"
 
 exec apache2-foreground


### PR DESCRIPTION
## Summary
- always run `composer create-project` when the container starts
- note unconditional execution in the docs
- record the change in the changelog

## Testing
- `bash -n web/entrypoint.sh`
- `docker compose config -q` *(fails: command not found)*